### PR TITLE
fix: 클릭업 조회 성능 개선

### DIFF
--- a/src/main/java/com/ai/dailyReport/reports/controller/ReportController.java
+++ b/src/main/java/com/ai/dailyReport/reports/controller/ReportController.java
@@ -2,7 +2,6 @@ package com.ai.dailyReport.reports.controller;
 
 
 import com.ai.dailyReport.auth.service.AuthService;
-import com.ai.dailyReport.common.exception.UnauthorizedException;
 import com.ai.dailyReport.common.response.ApiResponse;
 import com.ai.dailyReport.reports.dto.ReportCreateDto;
 import com.ai.dailyReport.reports.dto.ReportResponseDto;
@@ -57,7 +56,7 @@ public class ReportController {
     Authentication authentication
   )
   {
-    List<ReportResponseDto> reports = reportService.findByUserIdAndDateRange(userId, startDate, endDate);
+    List<ReportResponseDto> reports = reportService.findByUserIdAndDateRangeNoClickUp(userId, startDate, endDate);
     WeeklyPayload payload = new WeeklyPayload(startDate, endDate, reports);
     return ResponseEntity.ok(ApiResponse.success("주간 Report 조회에 성공했습니다.", payload));
   }
@@ -71,7 +70,7 @@ public class ReportController {
 	) {
 		Long userId = authService.getCurrentUserId(authentication);
 
-		List<ReportResponseDto> reports = reportService.findByUserIdAndDateRange(userId, startDate, endDate);
+    List<ReportResponseDto> reports = reportService.findByUserIdAndDateRangeNoClickUp(userId, startDate, endDate);
 		WeeklyPayload payload = new WeeklyPayload(startDate, endDate, reports);
 
 		return ResponseEntity.ok(ApiResponse.success("주간 Report 조회에 성공했습니다.", payload));

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -39,6 +39,7 @@ jwt:
 logging:
   level:
     com.dailyreport.backend: DEBUG
+    com.ai.dailyReport: DEBUG
     org.springframework.security: DEBUG
     org.hibernate.SQL: DEBUG
 


### PR DESCRIPTION
### 변경 사항
**ReportService**
- findByUserIdAndDateRangeNoClickUp(userId, startDate, endDate) 추가: 주간 조회용, ClickUp 호출 제외.
- findAllReports()를 ClickUp 미호출 버전으로 변경.
- createReportResponseWithoutClickUpData(report, viewerUserId) 추가: ClickUp 없이 mentions만 포함해 DTO 생성.

**ReportController**
- 주간 조회 2개 엔드포인트(/reports/weekly, /reports/weekly/{userId})를 findByUserIdAndDateRangeNoClickUp 사용으로 변경.
- 불필요 import 제거.

### 기타 사항
- 주간/전체에만 ClickUp 호출이 제거됨
- 단건 조회, 일간 조회는 기존대로 ClickUp 데이터를 포함